### PR TITLE
Activate in comment line, Changed label to \[look]

### DIFF
--- a/autoload/neocomplcache/sources/look.vim
+++ b/autoload/neocomplcache/sources/look.vim
@@ -11,7 +11,7 @@ function! s:source.finalize()
 endfunction
 
 function! s:source.get_keyword_list(cur_keyword_str)
-  if !neocomplcache#is_text_mode()
+  if !(neocomplcache#is_text_mode() || neocomplcache#within_comment())
         \ || a:cur_keyword_str !~ '^[[:alpha:]]\+$'
     return []
   endif


### PR DESCRIPTION
- Activate in comment line
  - Almost I use vim for source code, and feel painful google-ing every word (for spell check)...
  - I think this plugin will be perfect solution if enabled on comment line!
- Changed label to [look]
  - Because of visibility.
  - There're builtin sources which use label of [O], [F] and etc.
