### PR TITLE
always enable except non-alpha

### DIFF
--- a/autoload/neocomplcache/sources/look.vim
+++ b/autoload/neocomplcache/sources/look.vim
@@ -13,8 +13,7 @@ function! s:source.finalize()
 endfunction
 
 function! s:source.get_keyword_list(cur_keyword_str)
-  if !(neocomplcache#is_text_mode() || neocomplcache#within_comment())
-        \ || a:cur_keyword_str !~ '^[[:alpha:]]\+$'
+  if a:cur_keyword_str !~ '^[[:alpha:]]\+$'
     return []
   endif
   let list = split(neocomplcache#util#system(


### PR DESCRIPTION
neco-look doesn't show any words except i removing `!(neocomplcache#is_text_mode() || neocomplcache#within_comment())`
