### PR TITLE
Complement uppercase

### DIFF
--- a/autoload/neocomplcache/sources/look.vim
+++ b/autoload/neocomplcache/sources/look.vim
@@ -23,7 +23,7 @@ function! s:source.get_keyword_list(cur_keyword_str)
     return []
   endif
 
-  return list
+  return map(list, "substitute(v:val, '^' . tolower(a:cur_keyword_str), a:cur_keyword_str, '')")
 endfunction
 
 function! neocomplcache#sources#look#define()

--- a/autoload/neocomplete/sources/look.vim
+++ b/autoload/neocomplete/sources/look.vim
@@ -23,7 +23,7 @@ function! s:source.gather_candidates(context)
     return []
   endif
 
-  return list
+  return map(list, "substitute(v:val, '^' . tolower(a:context.complete_str), a:context.complete_str, '')")
 endfunction
 
 function! neocomplete#sources#look#define()


### PR DESCRIPTION


Before
---------

![before](https://cloud.githubusercontent.com/assets/4361134/8270280/7256be98-1813-11e5-933f-b95bd473dc53.png)

Words that begin with a capital L only is complemented.
But I think words that begin with a small l should be complemented.

After
---------

![after](https://cloud.githubusercontent.com/assets/4361134/8270300/d9e2c21e-1813-11e5-85cf-aea931c408da.png)

Words that begin with a small l came to be complemented.

----------

Output of look command

```sh
$ look l | head -20
l
L
la
La
LA
lab
Lab
Laban
label
labelled
labelling
labels
label's
labia
labial
labials
labial's
labile
labium
labium's
```

```sh
$ look l | head -20 | grep '^L'  # only starting uppercase
L
La
LA
Lab
Laban
```