### PR TITLE
Adding customization options for look words source and deoplete configs.

### DIFF
--- a/doc/neco-look.txt
+++ b/doc/neco-look.txt
@@ -7,16 +7,24 @@ Licence: GPL-3 or later
 ==============================================================================
 INTRODUCTION					*neco-look-introduction*
 
-Requirement:
-- Either
-  - neocomplcache.vim or
-  - neocomplete.vim
+Requirements:
+- One of
+  - neocomplcache.vim;
+  - neocomplete.vim; or
+  - deoplete
 - look command
 
 Latest version:
 https://github.com/ujihisa/neco-look
 
+==============================================================================
+VARIABLES                                        neco-look-variables
 
+                                        g:deoplete#look#words_source
+g:deoplete#look#words_source
+		Change the words source for the look command. This should be a
+                file with a word on each line in sorted order. Currently only
+                supported for the deoplete source.
 
 ==============================================================================
 vim:tw=78:fo=tcq2mM:ts=8:ft=help:norl

--- a/rplugin/python3/deoplete/sources/look.py
+++ b/rplugin/python3/deoplete/sources/look.py
@@ -15,16 +15,14 @@ class Source(Base):
         self.name = 'look'
         self.mark = '[look]'
 
-        def get_neco_look_var(shortname, default):
-            return vim.vars.get('deoplete#neco_look#{}'.format(shortname), default)
+        def get_look_var(shortname, default):
+            return vim.vars.get('deoplete#look#{}'.format(shortname), default)
 
-        self.min_pattern_length = get_neco_look_var('min_pattern_length', 4)
-        self.filetypes = get_neco_look_var('filetypes', [])
         self.is_volatile = True
 
         self.executable_look = self.vim.call('executable', 'look')
-        self.words_source = get_neco_look_var('words_source', None)
-        if self.words_source is not None:
+        self.words_source = get_look_var('words_source', None)
+        if self.words_source:
             self.words_source = os.path.expanduser(self.words_source)
 
     def _query_look(self, querystring):


### PR DESCRIPTION
I wanted to use a less-expansive dictionary than `/usr/share/dict/words`, so I used [this list of the 10000 most common words](https://github.com/first20hours/google-10000-english/blob/master/google-10000-english-usa.txt). 

Future tooling that would be nice to have would include 

1. fuzzy matching for completions with exact prefix matches preferred
2. ordering the above by usage frequency (so preserve the original version of the google-10000 list I use, which is ordered by frequency)
3. merging any custom source with `/usr/share/dict/words` so that you still have access to more than 10000 words by providing a list of `look#word_source` and running look for each source in the list, then merging the resulting candidates (I like this more than just merging the wordlists, and look is fast so 2-4x the calls is fine)