### PR TITLE
[bugfix] Cause error when querystring start with `-` 

### DIFF
--- a/rplugin/python3/deoplete/sources/look.py
+++ b/rplugin/python3/deoplete/sources/look.py
@@ -30,7 +30,7 @@ class Source(Base):
             self.words = expandvars(expanduser(self.words))
 
     def _query_look(self, querystring):
-        command = ['look', querystring]
+        command = ['look', '--', querystring]
 
         if self.words is not None:
             command.append(self.words)


### PR DESCRIPTION
## problem

When querystring start with `-`, The look command interprets that string as an option.

### Error Message

When querystring is `-p` .

```
look: illegal option -- p
usage: look [-df] [-t char] string [file ...]
```


## Solution

Insert `--` between the look command and querystring.

